### PR TITLE
Adding ppa:ondrej/php for consistency with our other PHP images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM 1and1internet/ubuntu-16-apache:latest
-MAINTAINER james.wilkins@fasthosts.co.uk
+MAINTAINER brian.wojtczak@1and1.co.uk
 ARG DEBIAN_FRONTEND=noninteractive
 COPY files /
 RUN \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   apt-get install -y software-properties-common python-software-properties && \
   add-apt-repository -y -u ppa:ondrej/php && \
   apt-get update && \
-  apt-get install -y libapache2-mod-php7.0 php7.0-cli php7.0-common php7.0-curl php7.0-gd php7.0-mysql php7.0-sqlite php7.0-xml php7.0-zip php7.0-mbstring php7.0-mcrypt php7.0-intl php7.0-soap php7.0-imap imagemagick php-imagick graphicsmagick php-gmagick && \
+  apt-get install -y libapache2-mod-php7.0 php7.0-cli php7.0-common php7.0-curl php7.0-gd php7.0-mysql php7.0-sqlite php7.0-xml php7.0-zip php7.0-mbstring php7.0-mcrypt php7.0-intl php7.0-soap php7.0-imap imagemagick php-imagick graphicsmagick && \
   sed -i -e 's/max_execution_time = 30/max_execution_time = 360/g' /etc/php/7.0/apache2/php.ini && \
   sed -i -e 's/upload_max_filesize = 2M/upload_max_filesize = 50M/g' /etc/php/7.0/apache2/php.ini && \
   sed -i -e 's/DirectoryIndex index.html index.cgi index.pl index.php index.xhtml index.htm/DirectoryIndex index.php index.html index.cgi index.pl index.xhtml index.htm/g' /etc/apache2/mods-available/dir.conf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 COPY files /
 RUN \
   apt-get update && \
+  apt-get install -y software-properties-common python-software-properties && \
+  add-apt-repository -y -u ppa:ondrej/php && \
+  apt-get update && \
   apt-get install -y libapache2-mod-php7.0 php7.0-cli php7.0-common php7.0-curl php7.0-gd php7.0-mysql php7.0-sqlite php7.0-xml php7.0-zip php7.0-mbstring php7.0-mcrypt php7.0-intl php7.0-soap php7.0-imap php-imagick && \
   sed -i -e 's/max_execution_time = 30/max_execution_time = 360/g' /etc/php/7.0/apache2/php.ini && \
   sed -i -e 's/upload_max_filesize = 2M/upload_max_filesize = 50M/g' /etc/php/7.0/apache2/php.ini && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   apt-get install -y software-properties-common python-software-properties && \
   add-apt-repository -y -u ppa:ondrej/php && \
   apt-get update && \
-  apt-get install -y libapache2-mod-php7.0 php7.0-cli php7.0-common php7.0-curl php7.0-gd php7.0-mysql php7.0-sqlite php7.0-xml php7.0-zip php7.0-mbstring php7.0-mcrypt php7.0-intl php7.0-soap php7.0-imap php-imagick && \
+  apt-get install -y libapache2-mod-php7.0 php7.0-cli php7.0-common php7.0-curl php7.0-gd php7.0-mysql php7.0-sqlite php7.0-xml php7.0-zip php7.0-mbstring php7.0-mcrypt php7.0-intl php7.0-soap php7.0-imap imagemagick php-imagick && \
   sed -i -e 's/max_execution_time = 30/max_execution_time = 360/g' /etc/php/7.0/apache2/php.ini && \
   sed -i -e 's/upload_max_filesize = 2M/upload_max_filesize = 50M/g' /etc/php/7.0/apache2/php.ini && \
   sed -i -e 's/DirectoryIndex index.html index.cgi index.pl index.php index.xhtml index.htm/DirectoryIndex index.php index.html index.cgi index.pl index.xhtml index.htm/g' /etc/apache2/mods-available/dir.conf && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN \
   apt-get install -y software-properties-common python-software-properties && \
   add-apt-repository -y -u ppa:ondrej/php && \
   apt-get update && \
-  apt-get install -y libapache2-mod-php7.0 php7.0-cli php7.0-common php7.0-curl php7.0-gd php7.0-mysql php7.0-sqlite php7.0-xml php7.0-zip php7.0-mbstring php7.0-mcrypt php7.0-intl php7.0-soap php7.0-imap imagemagick php-imagick && \
+  apt-get install -y libapache2-mod-php7.0 php7.0-cli php7.0-common php7.0-curl php7.0-gd php7.0-mysql php7.0-sqlite php7.0-xml php7.0-zip php7.0-mbstring php7.0-mcrypt php7.0-intl php7.0-soap php7.0-imap imagemagick php-imagick graphicsmagick php-gmagick && \
   sed -i -e 's/max_execution_time = 30/max_execution_time = 360/g' /etc/php/7.0/apache2/php.ini && \
   sed -i -e 's/upload_max_filesize = 2M/upload_max_filesize = 50M/g' /etc/php/7.0/apache2/php.ini && \
   sed -i -e 's/DirectoryIndex index.html index.cgi index.pl index.php index.xhtml index.htm/DirectoryIndex index.php index.html index.cgi index.pl index.xhtml index.htm/g' /etc/apache2/mods-available/dir.conf && \


### PR DESCRIPTION
Our PHP 5.6 image includes ppa:ondrej/php - not sure why, but some of the images based off it require packages in that repo rather than in the official Ubuntu repo.

Our new PHP 7.1 images require ppa:ondrej/php because 7.1 isn't available in the official Ubuntu repo.

Hence to make everything work in PHP 7.0 without finding a different approach to that used in the other version of PHP we have - we need access to the packages in ppa:ondrej/php